### PR TITLE
Lots of refactoring and reworking.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Set up database
         run: |
-          cargo install diesel_cli --no-default-features --features postgres
+          cargo install diesel_cli --no-default-features --features postgres --force
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -805,6 +806,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 name = "hubuum"
 version = "0.1.0"
 dependencies = [
+ "actix-rt",
  "actix-service",
  "actix-web",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-rt = "2.9.0"
 actix-service = "2.0.2"
 actix-web = { version = "4.4.1", features = ["actix-tls"] }
 argon2 = { version = "0.5.2", features = ["simple"] }

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -4,8 +4,9 @@ Hubuum divides user-created structures into classes and their objects. Objects a
 
 Permissions within Hubuum are based on the following principles:
 
-- Permissions are granted to groups and users on collections. Permissions are never granted to individual classes or objects.
-- Permissions are not inherited from any structure to any other. If a user has read access to a class, they do not automatically have read access to the objects of that class.
+- Permissions are granted to groups (only). If one wishes to grant permissions to a specific user only, create a group with a single member.
+- Permissions are granted on collections. Permissions are never granted to individual classes or objects.
+- Permissions are not inherited from any structure to any other. If a user (through a group membership) has read access to a class, they do not automatically have read access to the objects of that class.
 
 ## Permission types
 
@@ -27,7 +28,6 @@ The following permissions are available for collections:
 | `create_collection`   | Allows creating collections within the collection. |
 | `create_class`        | Allows creating classes within the collection. |
 | `create_object`       | Allows creating objects within the collection. |
-| ---------- | ----------- |
 
 The permission to grant groups (or users) access to the collection itself is done by the parent collection. Every collection has a parent collection and the root collection is created when the Hubuum instance is created.
 
@@ -41,7 +41,6 @@ The following permissions are available for classes:
 | `update_class`   | Allows updating the class (ie, change its name, its definition, validation requirements, etc). |
 | `delete_class`   | Allows deleting the class. Note that deleting a class deletes all objects belonging to that class. |
 | `create_object`  | Allows creating new objects of the class. |
-| ---------- | ----------- |
 
 ### Permissions for objects
 
@@ -52,7 +51,6 @@ The following permissions are available for objects:
 | `read_object`     | Allows reading the object. |
 | `update_object`   | Allows updating the object. |
 | `delete_object`   | Allows deleting the object. |
-| ---------- | ----------- |
 
 ## Example
 

--- a/migrations/2023-12-27-011440_initial/up.sql
+++ b/migrations/2023-12-27-011440_initial/up.sql
@@ -70,7 +70,7 @@ CREATE TABLE hubuumclass (
     id SERIAL PRIMARY KEY,
     name VARCHAR NOT NULL UNIQUE,
     namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
-    json_schema JSONB NOT NULL,
+    json_schema JSONB DEFAULT '{}'::jsonb NOT NULL,
     validate_schema BOOLEAN NOT NULL,
     description VARCHAR NOT NULL
 );
@@ -80,7 +80,7 @@ CREATE TABLE hubuumobject (
     name VARCHAR NOT NULL,
     namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
     hubuum_class_id INT REFERENCES hubuumclass (id) ON DELETE CASCADE NOT NULL,
-    data JSONB NOT NULL,
+    data JSONB DEFAULT '{}'::jsonb NOT NULL,
     description VARCHAR NOT NULL,
     UNIQUE (name, namespace_id)
 );

--- a/migrations/2023-12-27-011440_initial/up.sql
+++ b/migrations/2023-12-27-011440_initial/up.sql
@@ -31,51 +31,40 @@ CREATE TABLE namespaces (
     description VARCHAR NOT NULL
 );
 
-CREATE TABLE user_namespacepermissions (
-    id SERIAL PRIMARY KEY,
-    namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
-    user_id INT REFERENCES users (id) ON DELETE CASCADE NOT NULL,
-    has_create BOOLEAN NOT NULL,
-    has_read BOOLEAN NOT NULL,
-    has_update BOOLEAN NOT NULL,
-    has_delete BOOLEAN NOT NULL,
-    has_delegate BOOLEAN NOT NULL,
-    UNIQUE (namespace_id, user_id)
-);
-
-CREATE TABLE group_namespacepermissions (
+CREATE TABLE namespacepermissions (
     id SERIAL PRIMARY KEY,
     namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
     group_id INT REFERENCES groups (id) ON DELETE CASCADE NOT NULL,
-    has_create BOOLEAN NOT NULL,
-    has_read BOOLEAN NOT NULL,
-    has_update BOOLEAN NOT NULL,
-    has_delete BOOLEAN NOT NULL,
-    has_delegate BOOLEAN NOT NULL,
+    has_create_object BOOLEAN NOT NULL,
+    has_create_class BOOLEAN NOT NULL,
+    has_read_namespace BOOLEAN NOT NULL,
+    has_update_namespace BOOLEAN NOT NULL,
+    has_delete_namespace BOOLEAN NOT NULL,
+    has_delegate_namespace BOOLEAN NOT NULL,
     UNIQUE (namespace_id, group_id)
 );
 
-CREATE TABLE user_datapermissions (
-    id SERIAL PRIMARY KEY,
-    namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
-    user_id INT DEFAULT NULL REFERENCES users (id) ON DELETE CASCADE NOT NULL,
-    has_create BOOLEAN NOT NULL,
-    has_read BOOLEAN NOT NULL,
-    has_update BOOLEAN NOT NULL,
-    has_delete BOOLEAN NOT NULL,
-    UNIQUE (namespace_id, user_id)
-);
-
-CREATE TABLE group_datapermissions (
+CREATE TABLE classpermissions (
     id SERIAL PRIMARY KEY,
     namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
     group_id INT DEFAULT NULL REFERENCES groups (id) ON DELETE CASCADE NOT NULL,
-    has_create BOOLEAN NOT NULL,
-    has_read BOOLEAN NOT NULL,
-    has_update BOOLEAN NOT NULL,
-    has_delete BOOLEAN NOT NULL,
+    has_create_object BOOLEAN NOT NULL,
+    has_read_class BOOLEAN NOT NULL,
+    has_update_class BOOLEAN NOT NULL,
+    has_delete_class BOOLEAN NOT NULL,
     UNIQUE (namespace_id, group_id)
 );
+
+CREATE TABLE objectpermissions (
+    id SERIAL PRIMARY KEY,
+    namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
+    group_id INT DEFAULT NULL REFERENCES groups (id) ON DELETE CASCADE NOT NULL,
+    has_read_object BOOLEAN NOT NULL,
+    has_update_object BOOLEAN NOT NULL,
+    has_delete_object BOOLEAN NOT NULL,
+    UNIQUE (namespace_id, group_id)
+);
+
 
 CREATE TABLE hubuumclass (
     id SERIAL PRIMARY KEY,
@@ -96,26 +85,32 @@ CREATE TABLE hubuumobject (
     UNIQUE (name, namespace_id)
 );
 
+----------------------
+---- Indexes
+----------------------
+
+---- Users and groups
 CREATE INDEX idx_users_username ON users(username);
 CREATE INDEX idx_groups_groupname ON groups(groupname);
-CREATE INDEX idx_namespaces_name ON namespaces(name);
 CREATE INDEX idx_user_groups_user_id ON user_groups(user_id);
 CREATE INDEX idx_user_groups_group_id ON user_groups(group_id);
+
+---- Namespaces and tokens
+CREATE INDEX idx_namespaces_name ON namespaces(name);
 CREATE INDEX idx_tokens_user_id ON tokens(user_id);
 
-CREATE INDEX idx_user_namespacepermissions_namespace_id ON user_namespacepermissions(namespace_id);
-CREATE INDEX idx_user_namespacepermissions_user_id ON user_namespacepermissions(user_id);
-
-CREATE INDEX idx_user_datapermissions_namespace_id ON user_datapermissions(namespace_id);
-CREATE INDEX idx_user_datapermissions_user_id ON user_datapermissions(user_id);
-
-CREATE INDEX idx_group_namespacepermissions_namespace_id ON group_namespacepermissions(namespace_id);
-CREATE INDEX idx_group_namespacepermissions_group_id ON group_namespacepermissions(group_id);
-
-CREATE INDEX idx_group_datapermissions_namespace_id ON group_datapermissions(namespace_id);
-CREATE INDEX idx_group_datapermissions_group_id ON group_datapermissions(group_id);
-
+---- Classes and objects
 CREATE INDEX idx_hubuumclass_namespace_id ON hubuumclass(namespace_id);
 CREATE INDEX idx_hubuumobject_namespace_id ON hubuumobject(namespace_id);
 CREATE INDEX idx_hubuumobject_hubuum_class_id ON hubuumobject(hubuum_class_id);
+
+---- Permissions
+CREATE INDEX idx_namespacepermissions_namespace_id ON namespacepermissions(namespace_id);
+CREATE INDEX idx_namespacepermissions_group_id ON namespacepermissions(group_id);
+
+CREATE INDEX idx_classpermissions_namespace_id ON classpermissions(namespace_id);
+CREATE INDEX idx_classpermissions_group_id ON classpermissions(group_id);
+
+CREATE INDEX idx_objectpermissions_namespace_id ON classpermissions(namespace_id);
+CREATE INDEX idx_objectpermissions_group_id ON classpermissions(group_id);
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -35,7 +35,7 @@ export HUBUUM_DATABASE_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$
 diesel migration run --migration-dir $MIGRATIONS_DIR --database-url $HUBUUM_DATABASE_URL
 
 # Run the tests
-cargo test
+cargo test $@
 
 # Optional: Drop the test database after tests are complete
 PGPASSWORD=$DB_PASSWORD dropdb -h $DB_HOST -p $DB_PORT -U $DB_USER $TEST_DB_NAME

--- a/src/api/v1/handlers/namespaces.rs
+++ b/src/api/v1/handlers/namespaces.rs
@@ -1,8 +1,10 @@
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::extractors::{AdminAccess, UserAccess};
-use crate::models::namespace::{NamespaceID, NewNamespaceRequest, UpdateNamespace};
-use crate::models::permissions::{user_can_on_any, NamespacePermissions};
+use crate::models::namespace::{
+    user_can_on_any, NamespaceID, NewNamespaceRequest, UpdateNamespace,
+};
+use crate::models::permissions::NamespacePermissions;
 use crate::models::user::UserID;
 use crate::utilities::response::{json_response, json_response_created};
 use actix_web::{delete, get, http::StatusCode, patch, post, web, Responder};
@@ -19,8 +21,12 @@ pub async fn get_namespaces(
         requestor = requestor.user.username
     );
 
-    let result =
-        user_can_on_any(&pool, UserID(requestor.user.id), NamespacePermissions::Read).await?;
+    let result = user_can_on_any(
+        &pool,
+        UserID(requestor.user.id),
+        NamespacePermissions::ReadCollection,
+    )
+    .await?;
     Ok(json_response(result, StatusCode::OK))
 }
 
@@ -58,7 +64,11 @@ pub async fn get_namespace(
     );
 
     let namespace = namespace_id
-        .user_can(&pool, UserID(requestor.user.id), NamespacePermissions::Read)
+        .user_can(
+            &pool,
+            UserID(requestor.user.id),
+            NamespacePermissions::ReadCollection,
+        )
         .await?;
 
     Ok(json_response(namespace, StatusCode::OK))
@@ -81,7 +91,7 @@ pub async fn update_namespace(
         .user_can(
             &pool,
             UserID(requestor.user.id),
-            NamespacePermissions::Update,
+            NamespacePermissions::UpdateCollection,
         )
         .await?;
 
@@ -106,7 +116,7 @@ pub async fn delete_namespace(
         .user_can(
             &pool,
             UserID(requestor.user.id),
-            NamespacePermissions::Delete,
+            NamespacePermissions::DeleteCollection,
         )
         .await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
+#[cfg(not(test))]
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+#[cfg(not(test))]
 use tokio::sync::Mutex;
 
 #[derive(Parser, Debug, Deserialize, Serialize, Clone)]
@@ -34,8 +36,35 @@ pub struct AppConfig {
     pub db_pool_size: u32,
 }
 
+#[cfg(not(test))]
 pub static CONFIG: Lazy<Mutex<AppConfig>> = Lazy::new(|| Mutex::new(AppConfig::parse()));
 
+#[cfg(not(test))]
 pub async fn get_config() -> tokio::sync::MutexGuard<'static, AppConfig> {
     CONFIG.lock().await
+}
+
+#[cfg(test)]
+pub async fn get_config() -> AppConfig {
+    use std::env;
+
+    // Helper function to read an environment variable or return a default value
+    fn env_or_default(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    AppConfig {
+        bind_ip: env_or_default("HUBUUM_BIND_IP", "127.0.0.1"),
+        port: env_or_default("HUBUUM_BIND_PORT", "8080")
+            .parse()
+            .unwrap_or(8080),
+        log_level: env_or_default("HUBUUM_LOG_LEVEL", "debug"),
+        database_url: env_or_default("HUBUUM_DATABASE_URL", "postgres://test"),
+        actix_workers: env_or_default("HUBUUM_ACTIX_WORKERS", "2")
+            .parse()
+            .unwrap_or(2),
+        db_pool_size: env_or_default("HUBUUM_DB_POOL_SIZE", "2")
+            .parse()
+            .unwrap_or(5),
+    }
 }

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -7,6 +7,9 @@ use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::schema::hubuumclass;
 
+use crate::models::permissions::ClassPermissions;
+use crate::models::user::UserID;
+
 #[derive(Serialize, Deserialize, Queryable, Insertable)]
 #[diesel(table_name = hubuumclass )]
 pub struct HubuumClass {
@@ -16,6 +19,33 @@ pub struct HubuumClass {
     pub json_schema: Option<JsonValue>,
     pub validate_schema: bool,
     pub description: String,
+}
+
+impl HubuumClass {
+    pub async fn user_can(
+        &self,
+        pool: &DbPool,
+        user_id: UserID,
+        permission: ClassPermissions,
+    ) -> Result<bool, ApiError> {
+        use crate::models::permissions::ClassPermission;
+        use crate::models::permissions::PermissionFilter;
+        use crate::schema::classpermissions::dsl::*;
+
+        let mut conn = pool.get()?;
+        let group_id_subquery = user_id.group_ids_subquery();
+
+        let base_query = classpermissions
+            .into_boxed()
+            .filter(namespace_id.eq(self.namespace_id))
+            .filter(group_id.eq_any(group_id_subquery));
+
+        let result = PermissionFilter::filter(permission, base_query)
+            .first::<ClassPermission>(&mut conn)
+            .optional()?;
+
+        Ok(result.is_some())
+    }
 }
 
 pub async fn total_class_count(pool: &DbPool) -> Result<i64, ApiError> {

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -1,8 +1,6 @@
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use serde_json::Value as JsonValue;
-
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::schema::hubuumclass;
@@ -10,19 +8,65 @@ use crate::schema::hubuumclass;
 use crate::models::permissions::ClassPermissions;
 use crate::models::user::UserID;
 
-#[derive(Serialize, Deserialize, Queryable, Insertable)]
+use super::namespace::Namespace;
+
+#[derive(Serialize, Deserialize, Queryable, Insertable, Clone)]
 #[diesel(table_name = hubuumclass )]
 pub struct HubuumClass {
     pub id: i32,
     pub name: String,
     pub namespace_id: i32,
-    pub json_schema: Option<JsonValue>,
+    pub json_schema: serde_json::Value,
     pub validate_schema: bool,
     pub description: String,
 }
 
-impl HubuumClass {
-    pub async fn user_can(
+pub struct HubuumClassID(pub i32);
+
+pub trait ClassGenerics {
+    fn id(&self) -> i32;
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError>;
+    async fn namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError>;
+    async fn class(&self, pool: &DbPool) -> Result<HubuumClass, ApiError>;
+
+    /// Check if the user has the given permission on this class.
+    ///
+    /// If this is called on a HubuumClassID, a full HubuumClass is created to extract
+    /// the namespace_id. To avoid creating the HubuumClass multiple times during use
+    /// do this:
+    /// ```
+    /// class = class_id.class(pool).await?;
+    /// if (class.user_can(pool, userid, ClassPermissions::ReadClass).await?) {
+    ///     return Ok(class);
+    /// }
+    /// ```
+    /// And not this:
+    /// ```
+    /// if (class_id.user_can(pool, userid, ClassPermissions::ReadClass).await?) {
+    ///    return Ok(class_id.class(pool).await?);
+    /// }
+    /// ```
+    ///
+    /// ## Arguments
+    ///
+    /// * `pool` - The database pool to use for the query.
+    /// * `user_id` - The user to check permissions for.
+    /// * `permission` - The permission to check.
+    ///
+    /// ## Returns
+    ///
+    /// * `Ok(true)` if the user has the given permission on this class.
+    /// * `Ok(false)` if the user does not have the given permission on this class.
+    /// * `Err(_)` if the user does not have the given permission on this class, or if the
+    ///  permission is invalid.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// if (hubuum_class_or_classid.user_can(pool, userid, ClassPermissions::ReadClass).await?) {
+    ///     // Do something
+    /// }
+    async fn user_can(
         &self,
         pool: &DbPool,
         user_id: UserID,
@@ -35,9 +79,11 @@ impl HubuumClass {
         let mut conn = pool.get()?;
         let group_id_subquery = user_id.group_ids_subquery();
 
+        // Note that self.namespace_id(pool).await? is only a query if the caller is a HubuumClassID, otherwise
+        // it's a simple field access (which ignores the passed pool).
         let base_query = classpermissions
             .into_boxed()
-            .filter(namespace_id.eq(self.namespace_id))
+            .filter(namespace_id.eq(self.namespace_id(pool).await?))
             .filter(group_id.eq_any(group_id_subquery));
 
         let result = PermissionFilter::filter(permission, base_query)
@@ -45,6 +91,64 @@ impl HubuumClass {
             .optional()?;
 
         Ok(result.is_some())
+    }
+}
+
+impl ClassGenerics for HubuumClass {
+    fn id(&self) -> i32 {
+        self.id
+    }
+
+    async fn class(&self, _pool: &DbPool) -> Result<HubuumClass, ApiError> {
+        Ok(self.clone())
+    }
+
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
+        use crate::schema::namespaces::dsl::{id, namespaces};
+
+        let mut conn = pool.get()?;
+        let namespace = namespaces
+            .filter(id.eq(self.namespace_id))
+            .first::<Namespace>(&mut conn)?;
+
+        Ok(namespace)
+    }
+
+    async fn namespace_id(&self, _pool: &DbPool) -> Result<i32, ApiError> {
+        Ok(self.namespace_id)
+    }
+}
+
+impl ClassGenerics for HubuumClassID {
+    fn id(&self) -> i32 {
+        self.0
+    }
+
+    async fn class(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+        use crate::schema::hubuumclass::dsl::{hubuumclass, id};
+        use diesel::prelude::*;
+
+        let mut conn = pool.get()?;
+        let class = hubuumclass
+            .filter(id.eq(self.0))
+            .first::<HubuumClass>(&mut conn)?;
+
+        Ok(class)
+    }
+
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
+        use crate::schema::hubuumclass::dsl::{hubuumclass, id};
+
+        let mut conn = pool.get()?;
+        let class = hubuumclass
+            .filter(id.eq(self.0))
+            .first::<HubuumClass>(&mut conn)?;
+
+        class.namespace(pool).await
+    }
+
+    async fn namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError> {
+        Ok(self.namespace(pool).await?.id)
     }
 }
 

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -10,7 +10,7 @@ use crate::models::user::UserID;
 
 use super::namespace::Namespace;
 
-#[derive(Serialize, Deserialize, Queryable, Insertable, Clone)]
+#[derive(Serialize, Deserialize, Queryable, Clone, PartialEq, Debug)]
 #[diesel(table_name = hubuumclass )]
 pub struct HubuumClass {
     pub id: i32,
@@ -22,7 +22,19 @@ pub struct HubuumClass {
 }
 
 impl HubuumClass {
-    async fn delete(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+    pub async fn save(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+        let update = UpdateHubuumClass {
+            name: Some(self.name.clone()),
+            namespace_id: Some(self.namespace_id),
+            json_schema: Some(self.json_schema.clone()),
+            validate_schema: Some(self.validate_schema),
+            description: Some(self.description.clone()),
+        };
+
+        update.update(self.id, pool).await
+    }
+
+    pub async fn delete(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::*;
 
         let mut conn = pool.get()?;
@@ -43,7 +55,7 @@ pub struct NewHubuumClass {
 }
 
 impl NewHubuumClass {
-    async fn save(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+    pub async fn save(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::*;
 
         let mut conn = pool.get()?;
@@ -65,7 +77,7 @@ pub struct UpdateHubuumClass {
 }
 
 impl UpdateHubuumClass {
-    async fn update(&self, class_id: i32, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+    pub async fn update(&self, class_id: i32, pool: &DbPool) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::*;
 
         let mut conn = pool.get()?;
@@ -218,12 +230,12 @@ pub async fn total_class_count(pool: &DbPool) -> Result<i64, ApiError> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use crate::tests::{create_namespace, get_pool_and_config};
     //     use crate::tests::ensure_admin_group;
 
-    async fn verify_no_such_class(id: i32, pool: &DbPool) {
+    pub async fn verify_no_such_class(pool: &DbPool, id: i32) {
         match HubuumClassID(id).class(pool).await {
             Ok(_) => panic!("Class should not exist"),
             Err(e) => match e {
@@ -233,6 +245,26 @@ mod tests {
         }
     }
 
+    pub async fn get_class(id: i32, pool: &DbPool) -> HubuumClass {
+        HubuumClassID(id).class(pool).await.unwrap()
+    }
+
+    pub async fn create_class(
+        pool: &DbPool,
+        namespace: &Namespace,
+        class_name: &str,
+    ) -> HubuumClass {
+        let class = NewHubuumClass {
+            name: class_name.to_string(),
+            namespace_id: namespace.id,
+            json_schema: serde_json::Value::Null,
+            validate_schema: false,
+            description: "test".to_string(),
+        };
+
+        class.save(pool).await.unwrap()
+    }
+
     #[actix_rt::test]
     async fn test_creating_class_and_cascade_delete() {
         let (pool, _) = get_pool_and_config().await;
@@ -240,23 +272,66 @@ mod tests {
         let namespace = create_namespace(&pool, "test").await.unwrap();
         //        let admin_group = ensure_admin_group(&pool).await;
 
-        let class = NewHubuumClass {
-            name: "test".to_string(),
-            namespace_id: namespace.id,
-            json_schema: serde_json::Value::Null,
-            validate_schema: false,
-            description: "test".to_string(),
-        };
-
-        let class = class.save(&pool).await.unwrap();
+        let class_name = "test_creating_class";
+        let class = create_class(&pool, &namespace, class_name).await;
 
         assert_eq!(class.namespace_id(&pool).await.unwrap(), namespace.id);
-        assert_eq!(class.name, "test");
+        assert_eq!(class.name, class_name);
         assert_eq!(class.description, "test");
         assert_eq!(class.json_schema, serde_json::Value::Null);
 
+        let fetched_class = get_class(class.id, &pool).await;
+
+        assert_eq!(fetched_class, class);
+
         // Deleting the namespace should cascade away the class
         namespace.delete(&pool).await.unwrap();
-        verify_no_such_class(class.id, &pool).await;
+        verify_no_such_class(&pool, class.id).await;
+    }
+
+    #[actix_rt::test]
+    async fn test_updating_class_and_deleting_it() {
+        let (pool, _) = get_pool_and_config().await;
+        let namespace = create_namespace(&pool, "test").await.unwrap();
+        let class = create_class(&pool, &namespace, "test_updating_class").await;
+
+        let update = UpdateHubuumClass {
+            name: Some("test update 2".to_string()),
+            namespace_id: None,
+            json_schema: None,
+            validate_schema: None,
+            description: None,
+        };
+
+        let updated_class = update.update(class.id, &pool).await.unwrap();
+
+        assert_eq!(updated_class.id, class.id);
+        assert_eq!(updated_class.name, "test update 2");
+        assert_eq!(updated_class.namespace_id, class.namespace_id);
+        assert_eq!(updated_class.json_schema, class.json_schema);
+        assert_eq!(updated_class.validate_schema, class.validate_schema);
+        assert_eq!(updated_class.description, class.description);
+
+        updated_class.delete(&pool).await.unwrap();
+        verify_no_such_class(&pool, class.id).await;
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_rt::test]
+    async fn test_saving_after_changing_class() {
+        let (pool, _) = get_pool_and_config().await;
+        let namespace = create_namespace(&pool, "test").await.unwrap();
+        let mut class = create_class(&pool, &namespace, "test saving").await;
+
+        class.description = "new description".to_string();
+        class.save(&pool).await.unwrap();
+
+        let fetched_class = get_class(class.id, &pool).await;
+
+        assert_eq!(fetched_class.description, "new description");
+
+        namespace.delete(&pool).await.unwrap();
+        verify_no_such_class(&pool, class.id).await;
     }
 }

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -292,7 +292,7 @@ pub mod tests {
     #[actix_rt::test]
     async fn test_updating_class_and_deleting_it() {
         let (pool, _) = get_pool_and_config().await;
-        let namespace = create_namespace(&pool, "test").await.unwrap();
+        let namespace = create_namespace(&pool, "updating_class").await.unwrap();
         let class = create_class(&pool, &namespace, "test_updating_class").await;
 
         let update = UpdateHubuumClass {
@@ -321,7 +321,9 @@ pub mod tests {
     #[actix_rt::test]
     async fn test_saving_after_changing_class() {
         let (pool, _) = get_pool_and_config().await;
-        let namespace = create_namespace(&pool, "test").await.unwrap();
+        let namespace = create_namespace(&pool, "test_saving_after_changing_class")
+            .await
+            .unwrap();
         let mut class = create_class(&pool, &namespace, "test saving").await;
 
         class.description = "new description".to_string();

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -5,19 +5,18 @@ use crate::models::user::UserID;
 
 use crate::db::DbPool;
 
-use crate::schema::group_namespacepermissions;
+use crate::schema::namespacepermissions;
 use crate::schema::namespaces;
-use crate::schema::user_namespacepermissions;
 
-use crate::models::permissions::{
-    user_can_on, NewGroupNamespacePermission, NewUserNamespacePermission,
-};
+use crate::models::permissions::NewNamespacePermission;
 
 use crate::errors::ApiError;
 
-use crate::models::permissions::{Assignee, NamespacePermissions};
+use crate::models::permissions::NamespacePermissions;
 
-#[derive(Serialize, Deserialize, Queryable, PartialEq, Debug)]
+use super::group::GroupID;
+
+#[derive(Serialize, Deserialize, Queryable, PartialEq, Debug, Clone)]
 #[diesel(table_name = namespaces)]
 pub struct Namespace {
     pub id: i32,
@@ -42,7 +41,13 @@ impl Namespace {
         user_id: UserID,
         permission_type: NamespacePermissions,
     ) -> Result<Self, ApiError> {
-        user_can_on(pool, user_id, permission_type, NamespaceID(self.id)).await
+        user_can_on(
+            pool,
+            user_id,
+            permission_type,
+            NamespaceOrId::Namespace(self.clone()),
+        )
+        .await
     }
 
     /// Update a namespace
@@ -91,7 +96,7 @@ impl Namespace {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Copy, Clone)]
 pub struct NamespaceID(pub i32);
 
 impl NamespaceID {
@@ -101,7 +106,50 @@ impl NamespaceID {
         user_id: UserID,
         permission_type: NamespacePermissions,
     ) -> Result<Namespace, ApiError> {
-        user_can_on(pool, user_id, permission_type, NamespaceID(self.0)).await
+        user_can_on(
+            pool,
+            user_id,
+            permission_type,
+            NamespaceOrId::NamespaceId(*self),
+        )
+        .await
+    }
+
+    pub async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
+        use crate::schema::namespaces::dsl::*;
+
+        let mut conn = pool.get()?;
+        let namespace = namespaces
+            .filter(id.eq(self.0))
+            .first::<Namespace>(&mut conn)?;
+
+        Ok(namespace)
+    }
+}
+
+pub enum NamespaceOrId {
+    Namespace(Namespace),
+    NamespaceId(NamespaceID),
+}
+
+pub trait NamespaceRef {
+    fn id(&self) -> i32;
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError>;
+}
+
+impl NamespaceRef for NamespaceOrId {
+    fn id(&self) -> i32 {
+        match self {
+            NamespaceOrId::Namespace(ns) => ns.id,
+            NamespaceOrId::NamespaceId(id) => id.0,
+        }
+    }
+
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
+        match self {
+            NamespaceOrId::Namespace(ns) => Ok(ns.clone()),
+            NamespaceOrId::NamespaceId(id) => id.namespace(pool).await,
+        }
     }
 }
 
@@ -116,23 +164,11 @@ pub struct UpdateNamespace {
 pub struct NewNamespaceRequest {
     pub name: String,
     pub description: String,
-    pub assign_to_user_id: Option<i32>,
-    pub assign_to_group_id: Option<i32>,
+    pub group_id: i32,
 }
 
 impl NewNamespaceRequest {
-    pub fn validate(&self) -> Result<(), ApiError> {
-        match (self.assign_to_user_id, self.assign_to_group_id) {
-            (Some(_), None) | (None, Some(_)) => Ok(()),
-            _ => Err(ApiError::BadRequest(
-                "Exactly one of assign_to_user_id or assign_to_group_id must be set".to_string(),
-            )),
-        }
-    }
-
     pub async fn save_and_grant_all(self, pool: &DbPool) -> Result<Namespace, ApiError> {
-        self.validate()?;
-
         let new_namespace = NewNamespace {
             name: self.name,
             description: self.description,
@@ -145,38 +181,20 @@ impl NewNamespaceRequest {
                 .values(&new_namespace)
                 .get_result::<Namespace>(conn)?;
 
-            // Grant all permissions to the user or group
-            match (self.assign_to_user_id, self.assign_to_group_id) {
-                (Some(user_id), None) => {
-                    let user_permission = NewUserNamespacePermission {
-                        namespace_id: namespace.id,
-                        user_id,
-                        has_create: true,
-                        has_read: true,
-                        has_update: true,
-                        has_delete: true,
-                        has_delegate: true,
-                    };
-                    diesel::insert_into(crate::schema::user_namespacepermissions::table)
-                        .values(&user_permission)
-                        .execute(conn)?;
-                }
-                (None, Some(group_id)) => {
-                    let group_permission = NewGroupNamespacePermission {
-                        namespace_id: namespace.id,
-                        group_id,
-                        has_create: true,
-                        has_read: true,
-                        has_update: true,
-                        has_delete: true,
-                        has_delegate: true,
-                    };
-                    diesel::insert_into(crate::schema::group_namespacepermissions::table)
-                        .values(&group_permission)
-                        .execute(conn)?;
-                }
-                _ => return Err(ApiError::BadRequest("Invalid assignee".to_string())),
-            }
+            let group_permission = NewNamespacePermission {
+                namespace_id: namespace.id,
+                group_id: self.group_id,
+                has_create_object: true,
+                has_create_class: true,
+                has_read_namespace: true,
+                has_update_namespace: true,
+                has_delete_namespace: true,
+                has_delegate_namespace: true,
+            };
+
+            diesel::insert_into(crate::schema::namespacepermissions::table)
+                .values(&group_permission)
+                .execute(conn)?;
 
             Ok(namespace)
         })
@@ -194,7 +212,7 @@ impl NewNamespace {
     pub async fn save_and_grant_all_to(
         self,
         pool: &DbPool,
-        assignee: Assignee,
+        assignee: GroupID,
     ) -> Result<Namespace, ApiError> {
         use crate::schema::namespaces::dsl::*;
 
@@ -204,38 +222,20 @@ impl NewNamespace {
                 .values(&self)
                 .get_result::<Namespace>(conn)?;
 
-            match assignee {
-                Assignee::Group(group_id) => {
-                    let group_permission = NewGroupNamespacePermission {
-                        namespace_id: namespace.id,
-                        group_id: group_id.0,
-                        has_create: true,
-                        has_read: true,
-                        has_update: true,
-                        has_delete: true,
-                        has_delegate: true,
-                    };
+            let group_permission = NewNamespacePermission {
+                namespace_id: namespace.id,
+                group_id: assignee.0,
+                has_create_object: true,
+                has_create_class: true,
+                has_read_namespace: true,
+                has_update_namespace: true,
+                has_delete_namespace: true,
+                has_delegate_namespace: true,
+            };
 
-                    diesel::insert_into(group_namespacepermissions::table)
-                        .values(&group_permission)
-                        .execute(conn)?;
-                }
-                Assignee::User(user_id) => {
-                    let user_permission = NewUserNamespacePermission {
-                        namespace_id: namespace.id,
-                        user_id: user_id.0,
-                        has_create: true,
-                        has_read: true,
-                        has_update: true,
-                        has_delete: true,
-                        has_delegate: true,
-                    };
-
-                    diesel::insert_into(user_namespacepermissions::table)
-                        .values(&user_permission)
-                        .execute(conn)?;
-                }
-            }
+            diesel::insert_into(namespacepermissions::table)
+                .values(&group_permission)
+                .execute(conn)?;
 
             Ok(namespace)
         })
@@ -248,47 +248,115 @@ impl NewNamespace {
     ) -> Result<Namespace, ApiError> {
         use crate::schema::namespaces::dsl::*;
 
-        permissions.validate()?;
-
         let mut conn = pool.get()?;
         conn.transaction::<_, ApiError, _>(|conn| {
             let namespace = diesel::insert_into(namespaces)
                 .values(&self)
                 .get_result::<Namespace>(conn)?;
 
-            if let Some(user_id) = permissions.assign_to_user_id {
-                let user_permission = NewUserNamespacePermission {
-                    namespace_id: namespace.id,
-                    user_id,
-                    has_create: true,
-                    has_read: true,
-                    has_update: true,
-                    has_delete: true,
-                    has_delegate: true,
-                };
+            let group_permission = NewNamespacePermission {
+                namespace_id: namespace.id,
+                group_id: permissions.group_id,
+                has_create_object: true,
+                has_create_class: true,
+                has_read_namespace: true,
+                has_update_namespace: true,
+                has_delete_namespace: true,
+                has_delegate_namespace: true,
+            };
 
-                diesel::insert_into(user_namespacepermissions::table)
-                    .values(&user_permission)
-                    .execute(conn)?;
-            }
-
-            if let Some(group_id) = permissions.assign_to_group_id {
-                let group_permission = NewGroupNamespacePermission {
-                    namespace_id: namespace.id,
-                    group_id,
-                    has_create: true,
-                    has_read: true,
-                    has_update: true,
-                    has_delete: true,
-                    has_delegate: true,
-                };
-
-                diesel::insert_into(group_namespacepermissions::table)
-                    .values(&group_permission)
-                    .execute(conn)?;
-            }
+            diesel::insert_into(namespacepermissions::table)
+                .values(&group_permission)
+                .execute(conn)?;
 
             Ok(namespace)
         })
     }
+}
+
+/// Check if a user has a specific permission to a given namespace ID
+///
+/// ## Arguments
+///
+/// * pool - Database connection pool
+/// * user_id - ID of the user to check permissions for
+/// * permission_type - Type of permission to check
+/// * namespace_ref - Namespace or NamespaceID to check permissions for
+///
+/// ## Returns
+/// * Ok(Namespace) - Namespace if the user has the requested permission
+/// * Err(ApiError) - Always returns 404 if there is no match (we never do 403/401)
+pub async fn user_can_on(
+    pool: &DbPool,
+    user_id: UserID,
+    permission_type: NamespacePermissions,
+    namespace_ref: NamespaceOrId,
+) -> Result<Namespace, ApiError> {
+    use crate::models::permissions::{NamespacePermission, PermissionFilter};
+    use crate::schema::namespacepermissions::dsl::*;
+    use diesel::prelude::*;
+
+    let mut conn = pool.get()?;
+    let namespace_target_id = namespace_ref.id();
+
+    let group_ids_subquery = user_id.group_ids_subquery();
+
+    let base_query = namespacepermissions
+        .into_boxed()
+        .filter(namespace_id.eq(namespace_target_id))
+        .filter(group_id.eq_any(group_ids_subquery));
+
+    let result = PermissionFilter::filter(permission_type, base_query)
+        .first::<NamespacePermission>(&mut conn)
+        .optional()?;
+
+    if let Some(_) = result {
+        return Ok(namespace_ref.namespace(pool).await?);
+    }
+
+    Err(ApiError::NotFound("Not found".to_string()))
+}
+
+/// Check if a user has a specific permission to any namespace
+///
+/// ## Arguments
+/// * pool - Database connection pool
+/// * user_id - ID of the user to check permissions for
+/// * permission_type - Type of permission to check
+///
+/// ## Returns
+/// * Ok(Vec<Namespace>) - List of namespaces the user has the requested permission for.
+///                        If no matching namespaces are found, an empty list is returned
+/// * Err(ApiError) - On query errors only.
+pub async fn user_can_on_any(
+    pool: &DbPool,
+    user_id: UserID,
+    permission_type: NamespacePermissions,
+) -> Result<Vec<Namespace>, ApiError> {
+    use crate::models::permissions::PermissionFilter;
+
+    use crate::schema::namespacepermissions::dsl::*;
+    use diesel::prelude::*;
+
+    let mut conn = pool.get()?;
+
+    let group_ids_subquery = user_id.group_ids_subquery();
+
+    let base_query = namespacepermissions
+        .into_boxed()
+        .filter(group_id.eq_any(group_ids_subquery));
+
+    let filtered_query = PermissionFilter::filter(permission_type, base_query);
+
+    let accessible_namespace_ids = filtered_query.select(namespace_id).load::<i32>(&mut conn)?;
+
+    let accessible_namespaces = if !accessible_namespace_ids.is_empty() {
+        namespaces::table
+            .filter(namespaces::id.eq_any(accessible_namespace_ids))
+            .load::<Namespace>(&mut conn)?
+    } else {
+        vec![]
+    };
+
+    Ok(accessible_namespaces)
 }

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -125,7 +125,7 @@ impl NamespaceGenerics for NamespaceID {
     }
 
     async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
-        use crate::schema::namespaces::dsl::*;
+        use crate::schema::namespaces::dsl::{id, namespaces};
 
         let mut conn = pool.get()?;
         let namespace = namespaces

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -1,12 +1,15 @@
 use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Integer};
-use diesel::QueryableByName;
-
 use serde::{Deserialize, Serialize};
 
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::schema::hubuumobject;
+
+use crate::models::class::HubuumClass;
+use crate::models::namespace::Namespace;
+use crate::models::permissions::ObjectPermissions;
+use crate::models::user::UserID;
 
 #[derive(QueryableByName, Debug, Serialize, Deserialize)]
 pub struct ObjectsByClass {
@@ -16,16 +19,178 @@ pub struct ObjectsByClass {
     pub count: i64,
 }
 
-use serde_json::Value as JsonValue;
-#[derive(Serialize, Deserialize, Queryable, Insertable)]
-#[diesel(table_name = hubuumobject)]
+#[derive(Serialize, Deserialize, Queryable, Insertable, Clone)]
+#[diesel(table_name = hubuumobject )]
 pub struct HubuumObject {
     pub id: i32,
     pub name: String,
     pub namespace_id: i32,
     pub hubuum_class_id: i32,
-    pub data: Option<JsonValue>,
+    pub data: serde_json::Value,
     pub description: String,
+}
+
+pub struct HubuumObjectID(pub i32);
+
+pub trait ObjectGenerics {
+    fn id(&self) -> i32;
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError>;
+    async fn namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError>;
+    async fn class(&self, pool: &DbPool) -> Result<HubuumClass, ApiError>;
+    async fn class_id(&self, pool: &DbPool) -> Result<i32, ApiError>;
+    async fn object(&self, pool: &DbPool) -> Result<HubuumObject, ApiError>;
+
+    /// Check if the user has the given permission on this object.
+    ///
+    /// If this is called on a HubuumObjectID, a full HubuumObject is created to extract
+    /// the namespace_id. To avoid creating the HubuumObject multiple times during use
+    /// do this:
+    /// ```
+    /// obj = obj_id.Object(pool).await?;
+    /// if (obj.user_can(pool, userid, ObjectPermissions::ReadObject).await?) {
+    ///     return Ok(obj);
+    /// }
+    /// ```
+    /// And not this:
+    /// ```
+    /// if (obj_id.user_can(pool, userid, ObjectPermissions::ReadObject).await?) {
+    ///    return Ok(obj_id.Object(pool).await?);
+    /// }
+    /// ```
+    ///
+    /// ## Arguments
+    ///
+    /// * `pool` - The database pool to use for the query.
+    /// * `user_id` - The user to check permissions for.
+    /// * `permission` - The permission to check.
+    ///
+    /// ## Returns
+    ///
+    /// * `Ok(true)` if the user has the given permission on this object.
+    /// * `Ok(false)` if the user does not have the given permission on this object.
+    /// * `Err(_)` if the user does not have the given permission on this object, or if the
+    ///  permission is invalid.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// if (hubuum_object_or_objectid.user_can(pool, userid, ObjectPermissions::ReadObject).await?) {
+    ///     // Do something
+    /// }
+    async fn user_can(
+        &self,
+        pool: &DbPool,
+        user_id: UserID,
+        permission: ObjectPermissions,
+    ) -> Result<bool, ApiError> {
+        use crate::models::permissions::ObjectPermission;
+        use crate::models::permissions::PermissionFilter;
+        use crate::schema::objectpermissions::dsl::*;
+
+        let mut conn = pool.get()?;
+        let group_id_subquery = user_id.group_ids_subquery();
+
+        // Note that self.namespace_id(pool).await? is only a query if the caller is a HubuumObjectID, otherwise
+        // it's a simple field access (which ignores the passed pool).
+        let base_query = objectpermissions
+            .into_boxed()
+            .filter(namespace_id.eq(self.namespace_id(pool).await?))
+            .filter(group_id.eq_any(group_id_subquery));
+
+        let result = PermissionFilter::filter(permission, base_query)
+            .first::<ObjectPermission>(&mut conn)
+            .optional()?;
+
+        Ok(result.is_some())
+    }
+}
+
+impl ObjectGenerics for HubuumObject {
+    fn id(&self) -> i32 {
+        self.id
+    }
+
+    async fn object(&self, _pool: &DbPool) -> Result<HubuumObject, ApiError> {
+        Ok(self.clone())
+    }
+
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
+        use crate::schema::namespaces::dsl::{id, namespaces};
+
+        let mut conn = pool.get()?;
+        let namespace = namespaces
+            .filter(id.eq(self.namespace_id))
+            .first::<Namespace>(&mut conn)?;
+
+        Ok(namespace)
+    }
+
+    async fn namespace_id(&self, _pool: &DbPool) -> Result<i32, ApiError> {
+        Ok(self.namespace_id)
+    }
+
+    async fn class(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+        use crate::schema::hubuumclass::dsl::{hubuumclass, id};
+
+        let mut conn = pool.get()?;
+        let class = hubuumclass
+            .filter(id.eq(self.hubuum_class_id))
+            .first::<HubuumClass>(&mut conn)?;
+
+        Ok(class)
+    }
+
+    async fn class_id(&self, _pool: &DbPool) -> Result<i32, ApiError> {
+        Ok(self.hubuum_class_id)
+    }
+}
+
+impl ObjectGenerics for HubuumObjectID {
+    fn id(&self) -> i32 {
+        self.0
+    }
+
+    async fn object(&self, pool: &DbPool) -> Result<HubuumObject, ApiError> {
+        use crate::schema::hubuumobject::dsl::{hubuumobject, id};
+        use diesel::prelude::*;
+
+        let mut conn = pool.get()?;
+        let object = hubuumobject
+            .filter(id.eq(self.0))
+            .first::<HubuumObject>(&mut conn)?;
+
+        Ok(object)
+    }
+
+    async fn namespace(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
+        use crate::schema::hubuumobject::dsl::{hubuumobject, id};
+
+        let mut conn = pool.get()?;
+        let object = hubuumobject
+            .filter(id.eq(self.0))
+            .first::<HubuumObject>(&mut conn)?;
+
+        object.namespace(pool).await
+    }
+
+    async fn namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError> {
+        Ok(self.namespace(pool).await?.id)
+    }
+
+    async fn class(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+        use crate::schema::hubuumobject::dsl::{hubuumobject, id};
+
+        let mut conn = pool.get()?;
+        let object = hubuumobject
+            .filter(id.eq(self.0))
+            .first::<HubuumObject>(&mut conn)?;
+
+        object.class(pool).await
+    }
+
+    async fn class_id(&self, pool: &DbPool) -> Result<i32, ApiError> {
+        Ok(self.class(pool).await?.id)
+    }
 }
 
 pub async fn total_object_count(pool: &DbPool) -> Result<i64, ApiError> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,27 +1,14 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    group_datapermissions (id) {
+    classpermissions (id) {
         id -> Int4,
         namespace_id -> Int4,
         group_id -> Int4,
-        has_create -> Bool,
-        has_read -> Bool,
-        has_update -> Bool,
-        has_delete -> Bool,
-    }
-}
-
-diesel::table! {
-    group_namespacepermissions (id) {
-        id -> Int4,
-        namespace_id -> Int4,
-        group_id -> Int4,
-        has_create -> Bool,
-        has_read -> Bool,
-        has_update -> Bool,
-        has_delete -> Bool,
-        has_delegate -> Bool,
+        has_create_object -> Bool,
+        has_read_class -> Bool,
+        has_update_class -> Bool,
+        has_delete_class -> Bool,
     }
 }
 
@@ -56,10 +43,35 @@ diesel::table! {
 }
 
 diesel::table! {
+    namespacepermissions (id) {
+        id -> Int4,
+        namespace_id -> Int4,
+        group_id -> Int4,
+        has_create_object -> Bool,
+        has_create_class -> Bool,
+        has_read_namespace -> Bool,
+        has_update_namespace -> Bool,
+        has_delete_namespace -> Bool,
+        has_delegate_namespace -> Bool,
+    }
+}
+
+diesel::table! {
     namespaces (id) {
         id -> Int4,
         name -> Varchar,
         description -> Varchar,
+    }
+}
+
+diesel::table! {
+    objectpermissions (id) {
+        id -> Int4,
+        namespace_id -> Int4,
+        group_id -> Int4,
+        has_read_object -> Bool,
+        has_update_object -> Bool,
+        has_delete_object -> Bool,
     }
 }
 
@@ -72,34 +84,9 @@ diesel::table! {
 }
 
 diesel::table! {
-    user_datapermissions (id) {
-        id -> Int4,
-        namespace_id -> Int4,
-        user_id -> Int4,
-        has_create -> Bool,
-        has_read -> Bool,
-        has_update -> Bool,
-        has_delete -> Bool,
-    }
-}
-
-diesel::table! {
     user_groups (user_id, group_id) {
         user_id -> Int4,
         group_id -> Int4,
-    }
-}
-
-diesel::table! {
-    user_namespacepermissions (id) {
-        id -> Int4,
-        namespace_id -> Int4,
-        user_id -> Int4,
-        has_create -> Bool,
-        has_read -> Bool,
-        has_update -> Bool,
-        has_delete -> Bool,
-        has_delegate -> Bool,
     }
 }
 
@@ -112,31 +99,28 @@ diesel::table! {
     }
 }
 
-diesel::joinable!(group_datapermissions -> groups (group_id));
-diesel::joinable!(group_datapermissions -> namespaces (namespace_id));
-diesel::joinable!(group_namespacepermissions -> groups (group_id));
-diesel::joinable!(group_namespacepermissions -> namespaces (namespace_id));
+diesel::joinable!(classpermissions -> groups (group_id));
+diesel::joinable!(classpermissions -> namespaces (namespace_id));
 diesel::joinable!(hubuumclass -> namespaces (namespace_id));
 diesel::joinable!(hubuumobject -> hubuumclass (hubuum_class_id));
 diesel::joinable!(hubuumobject -> namespaces (namespace_id));
+diesel::joinable!(namespacepermissions -> groups (group_id));
+diesel::joinable!(namespacepermissions -> namespaces (namespace_id));
+diesel::joinable!(objectpermissions -> groups (group_id));
+diesel::joinable!(objectpermissions -> namespaces (namespace_id));
 diesel::joinable!(tokens -> users (user_id));
-diesel::joinable!(user_datapermissions -> namespaces (namespace_id));
-diesel::joinable!(user_datapermissions -> users (user_id));
 diesel::joinable!(user_groups -> groups (group_id));
 diesel::joinable!(user_groups -> users (user_id));
-diesel::joinable!(user_namespacepermissions -> namespaces (namespace_id));
-diesel::joinable!(user_namespacepermissions -> users (user_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
-    group_datapermissions,
-    group_namespacepermissions,
+    classpermissions,
     groups,
     hubuumclass,
     hubuumobject,
+    namespacepermissions,
     namespaces,
+    objectpermissions,
     tokens,
-    user_datapermissions,
     user_groups,
-    user_namespacepermissions,
     users,
 );

--- a/src/tests/api/v1/namespaces.rs
+++ b/src/tests/api/v1/namespaces.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_contains, assert_contains_all, assert_response_status};
-    use crate::tests::{create_namespace, ensure_admin_user, setup_pool_and_tokens};
+    use crate::tests::{create_namespace, ensure_admin_group, setup_pool_and_tokens};
     use actix_web::{http, test};
 
     const NAMESPACE_ENDPOINT: &str = "/api/v1/namespaces";
@@ -42,6 +42,7 @@ mod tests {
     #[actix_web::test]
     async fn test_create_patch_delete_namespace() {
         let (pool, admin_token, normal_token) = setup_pool_and_tokens().await;
+        let admin_group = ensure_admin_group(&pool).await;
 
         let resp = get_request(&pool, "", NAMESPACE_ENDPOINT).await;
         let _ = assert_response_status(resp, http::StatusCode::UNAUTHORIZED).await;
@@ -49,8 +50,7 @@ mod tests {
         let content = NewNamespaceRequest {
             name: "test_namespace_create".to_string(),
             description: "test namespace create description".to_string(),
-            assign_to_user_id: Some(ensure_admin_user(&pool).await.id),
-            assign_to_group_id: None,
+            group_id: admin_group.id,
         };
 
         let resp = post_request(&pool, &normal_token, NAMESPACE_ENDPOINT, &content).await;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,7 +17,6 @@ use crate::errors::ApiError;
 use crate::models::group::GroupID;
 use crate::models::group::{Group, NewGroup};
 use crate::models::namespace::{Namespace, NewNamespace};
-use crate::models::permissions::Assignee;
 use crate::models::user::{NewUser, User};
 
 use crate::utilities::auth::generate_random_password;
@@ -170,7 +169,7 @@ pub fn get_config_sync() -> AppConfig {
 
 pub async fn create_namespace(pool: &DbPool, ns_name: &str) -> Result<Namespace, ApiError> {
     let admin_group = ensure_admin_group(pool).await;
-    let assignee = Assignee::Group(GroupID(admin_group.id));
+    let assignee = GroupID(admin_group.id);
 
     NewNamespace {
         name: ns_name.to_string(),


### PR DESCRIPTION
  - Now back to only supporting group-based permissions (no direct user permissions).
  - Refactored a lot of the permissions code to use traits and generating subqueries in an more readable and efficient way (no more string-based field lookups).
  - Updated documentation to match code base.
  - Updated sql and schema.
  - Moved namespace-specific permissions code out of permissions.rs and into models/namespaces.rs
  - Renamed contents of permission enums to match documentation.